### PR TITLE
Improve dataset handling and suppress pandas warnings

### DIFF
--- a/envs/mpiejitj_env.py
+++ b/envs/mpiejitj_env.py
@@ -37,6 +37,8 @@ class MPIEIITJEnv(gym.Env):
 
         self.df   = df_num
         self.cols = list(df_num.columns)
+        if not self.cols:
+            raise ValueError("No numeric columns found after cleaning the dataset")
 
         # 2️⃣  fixed transform list (5 actions)
         self.transforms = ["pca", "dct", "wavelet", "fft", "polyfit"]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,69 @@
+# streamlit_app.py
+import streamlit as st
+import subprocess, tempfile, datetime
+import matplotlib.pyplot as plt
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+
+st.set_page_config(
+    page_title="Mathematical Pattern Discovery Engine",
+    layout="wide",
+)
+
+st.title("📐 Mathematical Pattern Discovery Engine")
+st.markdown("_An IIT-Jodhpur research project_")
+
+uploaded = st.file_uploader("Upload CSV / TXT", type=["csv", "txt"])
+
+def run_agent(path):
+    """Call your CLI and return raw stdout."""
+    proc = subprocess.run(
+        ["python", "analyze.py", "--data", path],
+        capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stdout + proc.stderr)
+    return proc.stdout
+
+if uploaded:
+    with st.spinner("Running RL agent…"):
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
+        tmp.write(uploaded.read()); tmp.close()
+
+        try:
+            raw = run_agent(tmp.name)
+        except Exception as e:
+            st.error(e)
+            st.stop()
+
+    st.subheader("Raw output")
+    st.code(raw, language="text")
+
+    # --- minimal parsing for demo (reuse parser you already wrote) ----
+    import re, json
+    reward = json.loads(
+        re.search(r"Reward break-down:\s*({.*})", raw).group(1).replace("'", '"')
+    )
+    st.subheader("Reward breakdown")
+    st.json(reward)
+
+    # chart of top relations
+    rel_lines = re.findall(r"(.*?)→(.*?)\s*deg=\d+\s*R²=([\d.]+)", raw)
+    if rel_lines:
+        plt.figure(figsize=(5,2.5))
+        labels = [f"{src.strip()}→{dst.strip()}" for src,dst,_ in rel_lines]
+        vals   = [float(r2) for *_, r2 in rel_lines]
+        plt.barh(labels, vals); plt.gca().invert_yaxis()
+        st.pyplot(plt)
+
+    # --- PDF report download -----------------------------------------
+    pdf_tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+    c = canvas.Canvas(pdf_tmp.name, pagesize=letter)
+    text = c.beginText(40, 750)
+    text.setFont("Helvetica", 11)
+    for line in raw.splitlines():
+        text.textLine(line)
+    c.drawText(text); c.showPage(); c.save()
+
+    with open(pdf_tmp.name, "rb") as f:
+        st.download_button("Download PDF", f, file_name="report.pdf")

--- a/utils/cleaner.py
+++ b/utils/cleaner.py
@@ -1,5 +1,6 @@
 # utils/cleaner.py
 import re
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -26,9 +27,13 @@ def _coerce_date_series(s: pd.Series, threshold: float = 0.8) -> pd.Series:
     if s.dtype != object:
         return s
 
-    # vectorized parses:
-    mdy = pd.to_datetime(s, errors="coerce", dayfirst=False)
-    dmy = pd.to_datetime(s, errors="coerce", dayfirst=True)
+    # vectorized parses – silence pandas warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        mdy = pd.to_datetime(s, errors="coerce", dayfirst=False,
+                             infer_datetime_format=True)
+        dmy = pd.to_datetime(s, errors="coerce", dayfirst=True,
+                             infer_datetime_format=True)
     r1, r2 = mdy.notna().mean(), dmy.notna().mean()
 
     if max(r1, r2) >= threshold:


### PR DESCRIPTION
## Summary
- suppress noisy pandas date parsing warnings
- fail early if a dataset contains no numeric columns

## Testing
- `python -m compileall -q .`
- `python analyze.py --data data/aapl_hist.csv` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68427ef895388332a8cdc29b09f1aabd